### PR TITLE
Feature: Add configurable field for issue name overrides

### DIFF
--- a/Jellyfin.Plugin.ComicVine/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.ComicVine/Configuration/PluginConfiguration.cs
@@ -12,5 +12,11 @@ namespace Jellyfin.Plugin.ComicVine.Configuration
         /// </summary>
         /// <remarks>The rate limit is 200 requests per resource, per hour.</remarks>
         public string ComicVineApiKey { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the issue number of a comic should be included on its name.
+        /// </summary>
+        /// <remarks>This will format the name like: Title (IssueNumber).</remarks>
+        public bool IncludeIssueNumberOnName { get; set; } = false;
     }
 }

--- a/Jellyfin.Plugin.ComicVine/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.ComicVine/Configuration/PluginConfiguration.cs
@@ -14,9 +14,12 @@ namespace Jellyfin.Plugin.ComicVine.Configuration
         public string ComicVineApiKey { get; set; } = string.Empty;
 
         /// <summary>
-        /// Gets or sets a value indicating whether the issue number of a comic should be included on its name.
+        /// Gets or sets the format for an issue's name.
         /// </summary>
-        /// <remarks>This will format the name like: Title (IssueNumber).</remarks>
-        public bool IncludeIssueNumberOnName { get; set; } = false;
+        /// <remarks>
+        /// This has the following available placeholders: {Name}, {Volume.Name}, {Id}, {IssueNumber}, {IssueNumberFormatted}.
+        /// If a value is missing or empty (no name or volume), its value will be replaced with the empty string.
+        /// </remarks>
+        public string IssueNameFormatOverride { get; set; } = string.Empty;
     }
 }

--- a/Jellyfin.Plugin.ComicVine/Configuration/configPage.html
+++ b/Jellyfin.Plugin.ComicVine/Configuration/configPage.html
@@ -16,6 +16,14 @@
                         <input id="comicVineApiKey" name="ComicVineApiKey" type="text" is="emby-input" required />
                         <div class="fieldDescription"> Comic Vine API Key. Get one <a href="https://comicvine.gamespot.com/api/" target="_blank">here</a>.</div>
                     </div>
+                    <label class="checkboxContainer emby-checkbox-label">
+                        <input class="emby-checkbox" data-embycheckbox="true" id="includeIssueNumberOnName" name="IncludeIssueNumberOnName" type="checkbox" is="emby-checkbox" />
+                        <span class="checkboxLabel"> Include the issue number on the name of the comic</span>
+                        <span class="checkboxOutline">
+                            <span class="material-icons checkboxIcon checkboxIcon-checked check" aria-hidden="true"></span>
+                            <span class="material-icons checkboxIcon checkboxIcon-unchecked " aria-hidden="true"></span>
+                        </span>
+                    </label>
                     <div>
                         <button is="emby-button" type="submit" class="raised button-submit block emby-button">
                             <span>Save</span>
@@ -34,6 +42,7 @@
                     Dashboard.showLoadingMsg();
                     ApiClient.getPluginConfiguration(TemplateConfig.pluginUniqueId).then(function (config) {
                         document.querySelector('#comicVineApiKey').value = config.ComicVineApiKey;
+                        document.querySelector('#includeIssueNumberOnName').checked = config.IncludeIssueNumberOnName;
                         Dashboard.hideLoadingMsg();
                     });
                 });
@@ -43,6 +52,7 @@
                     Dashboard.showLoadingMsg();
                     ApiClient.getPluginConfiguration(TemplateConfig.pluginUniqueId).then(function (config) {
                         config.ComicVineApiKey = document.querySelector('#comicVineApiKey').value;
+                        config.IncludeIssueNumberOnName = document.querySelector('#includeIssueNumberOnName').checked;
                         ApiClient.updatePluginConfiguration(TemplateConfig.pluginUniqueId, config).then(function (result) {
                             Dashboard.processPluginConfigurationUpdateResult(result);
                         });

--- a/Jellyfin.Plugin.ComicVine/Configuration/configPage.html
+++ b/Jellyfin.Plugin.ComicVine/Configuration/configPage.html
@@ -47,7 +47,7 @@
                     Dashboard.showLoadingMsg();
                     ApiClient.getPluginConfiguration(TemplateConfig.pluginUniqueId).then(function (config) {
                         document.querySelector('#comicVineApiKey').value = config.ComicVineApiKey;
-                        document.querySelector('#issueNameFormatOverride').checked = config.IssueNameFormatOverride;
+                        document.querySelector('#issueNameFormatOverride').value = config.IssueNameFormatOverride;
                         Dashboard.hideLoadingMsg();
                     });
                 });

--- a/Jellyfin.Plugin.ComicVine/Configuration/configPage.html
+++ b/Jellyfin.Plugin.ComicVine/Configuration/configPage.html
@@ -16,14 +16,19 @@
                         <input id="comicVineApiKey" name="ComicVineApiKey" type="text" is="emby-input" required />
                         <div class="fieldDescription"> Comic Vine API Key. Get one <a href="https://comicvine.gamespot.com/api/" target="_blank">here</a>.</div>
                     </div>
-                    <label class="checkboxContainer emby-checkbox-label">
-                        <input class="emby-checkbox" data-embycheckbox="true" id="includeIssueNumberOnName" name="IncludeIssueNumberOnName" type="checkbox" is="emby-checkbox" />
-                        <span class="checkboxLabel"> Include the issue number on the name of the comic</span>
-                        <span class="checkboxOutline">
-                            <span class="material-icons checkboxIcon checkboxIcon-checked check" aria-hidden="true"></span>
-                            <span class="material-icons checkboxIcon checkboxIcon-unchecked " aria-hidden="true"></span>
-                        </span>
-                    </label>
+                    <div class="inputContainer">
+                        <label class="inputLabel inputLabelUnfocused" for="issueNameFormatOverride">Issue Name Format Override</label>
+                        <input id="issueNameFormatOverride" name="IssueNameFormatOverride" type="text" is="emby-input" />
+                        <div class="fieldDescription"> An override for issue name formats. Leave blank for default behavior.</div>
+                        <div class="fieldDescription"> Available Placeholders:</div>
+                        <ul>
+                            <li class="fieldDescription">{Name} - Name of the issue. Blank if no name exists.</li>
+                            <li class="fieldDescription">{Volume.Name} - The volume name of the comic. Blank if no name exists.</li>
+                            <li class="fieldDescription">{Id} - The comic vine ID of the comic.</li>
+                            <li class="fieldDescription">{IssueNumber} - The raw issue number of the comic. (Example: 1, 5, 10)</li>
+                            <li class="fieldDescription">{IssueNumberFormatted} - The formatted issue number of the comic. (Example: 001, 005, 010).</li>
+                        </ul>
+                    </div>
                     <div>
                         <button is="emby-button" type="submit" class="raised button-submit block emby-button">
                             <span>Save</span>
@@ -42,7 +47,7 @@
                     Dashboard.showLoadingMsg();
                     ApiClient.getPluginConfiguration(TemplateConfig.pluginUniqueId).then(function (config) {
                         document.querySelector('#comicVineApiKey').value = config.ComicVineApiKey;
-                        document.querySelector('#includeIssueNumberOnName').checked = config.IncludeIssueNumberOnName;
+                        document.querySelector('#issueNameFormatOverride').checked = config.IssueNameFormatOverride;
                         Dashboard.hideLoadingMsg();
                     });
                 });
@@ -52,7 +57,7 @@
                     Dashboard.showLoadingMsg();
                     ApiClient.getPluginConfiguration(TemplateConfig.pluginUniqueId).then(function (config) {
                         config.ComicVineApiKey = document.querySelector('#comicVineApiKey').value;
-                        config.IncludeIssueNumberOnName = document.querySelector('#includeIssueNumberOnName').checked;
+                        config.IssueNameFormatOverride = document.querySelector('#issueNameFormatOverride').value;
                         ApiClient.updatePluginConfiguration(TemplateConfig.pluginUniqueId, config).then(function (result) {
                             Dashboard.processPluginConfigurationUpdateResult(result);
                         });

--- a/Jellyfin.Plugin.ComicVine/Providers/ComicVineMetadataProvider.cs
+++ b/Jellyfin.Plugin.ComicVine/Providers/ComicVineMetadataProvider.cs
@@ -107,7 +107,21 @@ namespace Jellyfin.Plugin.ComicVine.Providers
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            item.Name = !string.IsNullOrWhiteSpace(issue.Name) ? issue.Name : $"#{issue.IssueNumber.PadLeft(3, '0')}";
+            string issueName;
+            if (!string.IsNullOrWhiteSpace(issue.Name))
+            {
+                issueName = issue.Name;
+                if (Plugin.Instance!.Configuration.IncludeIssueNumberOnName)
+                {
+                    issueName += $" #{issue.IssueNumber.PadLeft(3, '0')}";
+                }
+            }
+            else
+            {
+                issueName = $"#{issue.IssueNumber.PadLeft(3, '0')}";
+            }
+
+            item.Name = issueName;
 
             string sortIssueName = issue.IssueNumber.PadLeft(3, '0');
 

--- a/Jellyfin.Plugin.ComicVine/Providers/ComicVineMetadataProvider.cs
+++ b/Jellyfin.Plugin.ComicVine/Providers/ComicVineMetadataProvider.cs
@@ -107,19 +107,7 @@ namespace Jellyfin.Plugin.ComicVine.Providers
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            string issueName;
-            if (!string.IsNullOrWhiteSpace(issue.Name))
-            {
-                issueName = issue.Name;
-                if (Plugin.Instance!.Configuration.IncludeIssueNumberOnName)
-                {
-                    issueName += $" #{issue.IssueNumber.PadLeft(3, '0')}";
-                }
-            }
-            else
-            {
-                issueName = $"#{issue.IssueNumber.PadLeft(3, '0')}";
-            }
+            string issueName = FormatIssueName(issue);
 
             item.Name = issueName;
 
@@ -380,6 +368,23 @@ namespace Jellyfin.Plugin.ComicVine.Providers
             }
 
             return result.Trim();
+        }
+
+        /// <summary>
+        /// Formats the issue name with the given details.
+        /// </summary>
+        /// <param name="details">The details to format.</param>
+        /// <returns>The formatted issue name.</returns>
+        private string FormatIssueName(IssueDetails details)
+        {
+            // Check if an override was provided
+            if (string.IsNullOrWhiteSpace(Plugin.Instance!.Configuration.IssueNameFormatOverride))
+            {
+                return !string.IsNullOrWhiteSpace(details.Name) ? details.Name : $"#{details.IssueNumber.PadLeft(3, '0')}";
+            }
+
+            string format = Plugin.Instance!.Configuration.IssueNameFormatOverride;
+            return format.Replace("{Name}", details.Name, StringComparison.Ordinal).Replace("{Volume.Name}", details.Volume?.Name, StringComparison.Ordinal).Replace("{Id}", $"{details.Id}", StringComparison.Ordinal).Replace("{IssueNumber}", details.IssueNumber, StringComparison.Ordinal).Replace("{IssueNumberFormatted}", $"{details.IssueNumber.PadLeft(3, '0')}", StringComparison.Ordinal).Trim();
         }
     }
 }

--- a/Jellyfin.Plugin.ComicVine/Providers/ComicVineMetadataProvider.cs
+++ b/Jellyfin.Plugin.ComicVine/Providers/ComicVineMetadataProvider.cs
@@ -107,9 +107,7 @@ namespace Jellyfin.Plugin.ComicVine.Providers
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            string issueName = FormatIssueName(issue);
-
-            item.Name = issueName;
+            item.Name = FormatIssueName(issue);
 
             string sortIssueName = issue.IssueNumber.PadLeft(3, '0');
 


### PR DESCRIPTION
This is a feature PR. I did not see any formats available, so please let me know if anything needs changed.

# Feature Added:
A configurable field for overriding the issue name format used by the plugin. Previously, it was impossible to change the format used by the plugin when naming comic issues.

## Previous Behavior:
Here's an example for Sonic the Hedgehog (1993) Issue #8:
<img width="816" height="887" alt="Screenshot_20260211_095924" src="https://github.com/user-attachments/assets/5a8bceeb-c8fb-4d84-bf17-f52bca9f8eff" />
The issue did not include the issue number or volume name and thus was unsearchable using that information.

## New Behavior:
The added configurable field allows for users to change how comics are named based upon the issue details provided by ComicVine. Example usage:
<img width="910" height="255" alt="Screenshot_20260211_095910" src="https://github.com/user-attachments/assets/89384193-ec48-498b-bea8-34cb11e90c0d" />

<img width="1249" height="877" alt="Screenshot_20260211_095904" src="https://github.com/user-attachments/assets/1164823b-0918-4d28-8359-7274f90940e5" />

If the field in the config is left blank, the original default behavior is used.

## Comments
If there's more information that should be available (or ideas on how to better handle formatted issue numbers) please let me know.